### PR TITLE
fix: break 401 redirect loop on login and handle post-login errors gr…

### DIFF
--- a/features/auth/components/login-form.tsx
+++ b/features/auth/components/login-form.tsx
@@ -19,7 +19,7 @@ import { AuthCardShell } from './container/auth-card-shell';
 
 export function LoginForm() {
   const { Auth } = useI18n();
-  const { setToken } = useAuthToken();
+  const { setToken, removeToken } = useAuthToken();
   const queryClient = useQueryClient();
   const router = useRouter();
   const [showPassword, setShowPassword] = React.useState(false);
@@ -32,14 +32,17 @@ export function LoginForm() {
     resolver: zodResolver(loginSchema),
     defaultValues: { email: '', password: '' },
   });
-
   const { mutateAsync: login, isPending } = useLoginMutation();
 
   const onSubmit = async (data: LoginFormValues) => {
-    const { accessToken } = await login(data);
-    setToken(accessToken);
-    toast.success('Welcome back!');
-    await postSubmission();
+    try {
+      const { accessToken } = await login(data);
+      setToken(accessToken);
+      await postSubmission();
+      toast.success('Welcome back!');
+    } catch {
+      removeToken();
+    }
   };
 
   const postSubmission = async () => {

--- a/features/onboarding/contexts/workspace-config-context.tsx
+++ b/features/onboarding/contexts/workspace-config-context.tsx
@@ -13,7 +13,10 @@ interface WorkspaceConfigContextValue {
 const WorkspaceConfigContext = createContext<WorkspaceConfigContextValue | null>(null);
 
 export function WorkspaceConfigProvider({ children }: { children: ReactNode }) {
-  const { data: onboardingConfig, isLoading } = useQuery(workspaceQueries.config());
+  const { data: onboardingConfig, isLoading } = useQuery({
+    ...workspaceQueries.config(),
+    throwOnError: false,
+  });
 
   return (
     <WorkspaceConfigContext.Provider value={{ onboardingConfig, isLoading }}>

--- a/hooks/use-auth-token.ts
+++ b/hooks/use-auth-token.ts
@@ -1,6 +1,6 @@
 import Cookies from 'js-cookie';
 
-const TOKEN_KEY = 'auth_token';
+export const TOKEN_KEY = 'auth_token';
 
 export const useAuthToken = () => {
   const getToken = () => Cookies.get(TOKEN_KEY);

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -1,5 +1,6 @@
 import axios, { type AxiosError, type AxiosRequestConfig } from 'axios';
-import { getAuthToken } from '@/hooks/use-auth-token';
+import Cookies from 'js-cookie';
+import { getAuthToken, TOKEN_KEY } from '@/hooks/use-auth-token';
 
 const apiClient = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL || '',
@@ -22,12 +23,15 @@ apiClient.interceptors.request.use(
 apiClient.interceptors.response.use(
   (response) => response,
   (error) => {
-    // 1. Handle Unauthorized (401)
+    // 1. Handle Unauthorized (401) — only for PROTECTED endpoints
     const isAuthRequest = error.config?.url?.includes('/auth/');
 
     if (error.response?.status === 401 && !isAuthRequest) {
-      // Clear token and redirect to login only for PROTECTED requests
-      if (typeof window !== 'undefined') {
+      // Clear stale token so it doesn't poison subsequent requests
+      Cookies.remove(TOKEN_KEY);
+
+      // Only redirect if we're not already on the login page to avoid reload loops
+      if (typeof window !== 'undefined' && window.location.pathname !== '/') {
         window.location.href = '/';
       }
     }


### PR DESCRIPTION
…acefully

- Clear stale token on 401 to prevent poisoned subsequent requests
- Skip hard redirect to `/` when already on login page
- Wrap postSubmission in try/catch so post-login failures don't cause redirect loops
- Suppress throwOnError on `/onboarding/config` query so a failed fetch doesn't crash the workspace layout